### PR TITLE
retrieveMetadata Endpoint

### DIFF
--- a/src/main/java/com/salesforce/scmt/controller/DeskController.java
+++ b/src/main/java/com/salesforce/scmt/controller/DeskController.java
@@ -30,5 +30,7 @@ public class DeskController
         post(PREFIX_URI + "/MigrateMetadata", (req, res) -> { return DeskService.migrateMetadata(req, res); }, new JsonTransformer());
         post(PREFIX_URI + "/MigrateData", (req, res) -> { return DeskService.migrateData(req, res); }, new JsonTransformer());
         post(PREFIX_URI + "/MigrateAttachments", (req, res) -> { return DeskService.migrateAttachments(req, res); }, new JsonTransformer());
+
+        post(PREFIX_URI + "/retrieveMetadata", (req, res) -> { return DeskService.retrieveMetadata(req, res); }, new JsonTransformer());
     }
 }


### PR DESCRIPTION
A new endpoint that retrieves users, groups and custom fields from Desk.com and returns the full data in the response.

`POST /desk/retrieveMetadata`

```
{
  "custom_fields": [{}],
  "groups": [{}],
  "users": [{}]
}
```