### PR TITLE
Query Desk Migration & Sum Totals

### DIFF
--- a/src/main/java/com/salesforce/scmt/worker/ClosedWorker.java
+++ b/src/main/java/com/salesforce/scmt/worker/ClosedWorker.java
@@ -66,8 +66,8 @@ public class ClosedWorker implements Runnable {
             JobInfo job   = sf.awaitCompletion(jobId);
             SObject mig   = getDeskMigration();
 
-            int failed    = job.getNumberRecordsFailed() + Integer.valueOf((String) mig.getField(DeskMigrationFields.RecordsFailed));
-            int processed = job.getNumberRecordsProcessed() + Integer.valueOf((String) mig.getField(DeskMigrationFields.RecordsTotal));
+            int failed    = job.getNumberRecordsFailed() + Double.valueOf((String) mig.getField(DeskMigrationFields.RecordsFailed)).intValue();
+            int processed = job.getNumberRecordsProcessed() + Double.valueOf((String) mig.getField(DeskMigrationFields.RecordsTotal)).intValue();
 
             sf.updateMigration(migrationId, failed, processed);
             sf.updateCustomLabel("BypassProcessBuilder", "0");

--- a/src/main/java/com/salesforce/scmt/worker/ClosedWorker.java
+++ b/src/main/java/com/salesforce/scmt/worker/ClosedWorker.java
@@ -66,8 +66,8 @@ public class ClosedWorker implements Runnable {
             JobInfo job   = sf.awaitCompletion(jobId);
             SObject mig   = getDeskMigration();
 
-            int failed    = job.getNumberRecordsFailed() + (int) mig.getField(DeskMigrationFields.RecordsFailed);
-            int processed = job.getNumberRecordsProcessed() + (int) mig.getField(DeskMigrationFields.RecordsTotal);
+            int failed    = job.getNumberRecordsFailed() + Integer.valueOf((String) mig.getField(DeskMigrationFields.RecordsFailed));
+            int processed = job.getNumberRecordsProcessed() + Integer.valueOf((String) mig.getField(DeskMigrationFields.RecordsTotal));
 
             sf.updateMigration(migrationId, failed, processed);
             sf.updateCustomLabel("BypassProcessBuilder", "0");


### PR DESCRIPTION
For every batch job that's closed in Salesforce we fetch the associated Desk Migration record and sum up the total Failed and Processed records. That way we allow to run multiple jobs for one Desk Migration while still having correct numbers.